### PR TITLE
Added support for any color format (not tested), opacity and outputs rgba

### DIFF
--- a/colorpick.m
+++ b/colorpick.m
@@ -25,6 +25,8 @@
 -(NSString *)toRGBString:(BOOL)shortVersion;
 -(NSString *)toRGBAString:(BOOL)shortVersion;
 
+-(NSString *)toSmartString; // opacity == 1 hex : rgba
+
 -(NSString *)toHSLString:(BOOL)shortVersion;
 -(NSString *)toHSLAString:(BOOL)shortVersion;
 
@@ -170,6 +172,12 @@
                        (float)[color alphaComponent]];
   
   return result;
+}
+
+-(NSString *)toSmartString {
+  NSColor *color = [self colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+  
+  return ((float)[color alphaComponent] < 1) ? [self toRGBAString:false] : [self toHexString];
 }
 
 -(NSString *)toHSLString:(BOOL)shortVersion {
@@ -327,7 +335,7 @@
 }
 
 - (void)writeColor {
-  NSString *hex = [panel.color toRGBAString:false];
+  NSString *hex = [panel.color toSmartString];
 
   // save color and current mode to defaults
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];


### PR DESCRIPTION
Never coded in Objective C before, and this is a bunch of copy pasta, so be warned.

Changes:
- Added functions from https://github.com/lifedispenser/ColorPicker/blob/master/NSColorAdditions.m
- Input now interprets many different correct color formats (hex, rgb, rgba, hsl, etc)
- Opacity turned on
- Outputs to rgba() instead of hex.

TODO before merge
- Tests to make sure I didn't leave anything segfaulting
- There can be a smarter output instead of just outputting rgba. If opacity is 1, then output hex. Otherwise, output rgba.
